### PR TITLE
1階層持て余す為3階層構造に戻す

### DIFF
--- a/buildCmd/python/create/mod.go
+++ b/buildCmd/python/create/mod.go
@@ -34,11 +34,11 @@ func Module(outFilePath string, tmplTxt string, inputData interface{}) error {
 	return nil
 }
 
-func Mod3Comment(location string, mod1Name string, mod2Name string, mod3Name string, comment string) string {
-    f := `""" <location: %s.%s.%s.%s />
+func EndModComment(location string, mod1Name string, mod2Name string, comment string) string {
+    f := `""" <location: %s.%s.%s />
 
 %s
 
 """`
-    return fmt.Sprintf(f, location,  mod1Name, mod2Name, mod3Name, comment)
+    return fmt.Sprintf(f, location,  mod1Name, mod2Name, comment)
 }

--- a/buildCmd/python/get/mod.go
+++ b/buildCmd/python/get/mod.go
@@ -1,49 +1,36 @@
 package get
 
-var clerkRootTemplate = `{{ $location := .Clerk.Location -}}
-{{ range .Clerk.Modules -}}
-import {{ $location }}.{{ .Name }}
+var mod0Template = `{{ $location := .Mod0.Location -}}
+{{ range .Mod0.Modules -}}
+import clerk.{{ $location }}.{{ .Name }}
 {{ end -}}
 {{ printf "\n" -}}
 {{ printf "\n" -}}
 def Clerk(location):
     match location:
-{{ range .Clerk.Modules -}}
-{{"        "}}case {{ printf "%q" .Name }}: return {{ $location }}.{{ .Name }}.Clerk{{- printf "\n" -}}
-{{- end -}}
-`
-
-var mod1Template = `{{ $location := .Location -}}
-{{ $mod1_name := .Mod1.Name -}}
-{{ range .Mod1.Upstreams -}}
-import {{ $location }}.{{ $mod1_name }}.{{ .Name }}
-{{ end -}}
-{{ printf "\n" -}}
-{{ printf "\n" -}}
-def Clerk(location):
-    match location:
-{{ range .Mod1.Upstreams -}}
-{{"        "}}case {{ printf "%q" .Name }}: return {{ $location }}.{{ $mod1_name }}.{{ .Name }}.Clerk{{- printf "\n" -}}
+{{ range .Mod0.Modules -}}
+{{"        "}}case {{ printf "%q" .Name }}: return clerk.{{ $location }}.{{ .Name }}.Clerk{{- printf "\n" -}}
 {{- end -}}`
 
-var mod2Template = `{{ $location := .Location -}}
+
+var mod1Template = `{{ $location := .Mod0.Location -}}
 {{ $mod1_name := .Mod1.Name -}}
-{{ $mod2_name := .Mod2.Name -}}
-{{ range .Mod2.Upstreams -}}
-import {{ $location }}.{{ $mod1_name }}.{{ $mod2_name }}.{{ .Name }}
+{{ range .Mod1.Upstreams -}}
+import clerk.{{ $location }}.{{ $mod1_name }}.{{ .Name }}
 {{ end -}}
 {{ printf "\n" -}}
 {{ printf "\n" -}}
 def Clerk(location):
     match location:
-{{ range .Mod2.Upstreams -}}
-{{"        "}}case {{ printf "%q" .Name }}: return {{ $location }}.{{ $mod1_name }}.{{ $mod2_name }}.{{ .Name }}.Clerk{{- printf "\n" -}}
+{{ range .Mod1.Upstreams -}}
+{{"        "}}case {{ printf "%q" .Name }}: return clerk.{{ $location }}.{{ $mod1_name }}.{{ .Name }}.Clerk{{- printf "\n" -}}
 {{- end -}}`
 
-var mod3Template = `{{ $location := .Location -}}
-""" <location: {{ $location }}.{{ .Mod1.Name }}.{{ .Mod2.Name }}.{{ .Mod3.Name }} />
 
-{{.Mod3.Comment}}
+var mod2Template = `{{ $location := .Mod0.Location -}}
+""" <location: {{ $location }}.{{ .Mod1.Name }}.{{ .Mod2.Name }} />
+
+{{.Mod2.Comment}}
 
 """
 
@@ -53,10 +40,9 @@ def Clerk():
 
 func ModuleTemplate(modLevel string) string {
     tmpl := map[string]string{
-        "clerkRoot": clerkRootTemplate,
+        "mod0": mod0Template,
         "mod1": mod1Template,
         "mod2": mod2Template,
-        "mod3": mod3Template,
     }
     return tmpl[modLevel]
 }

--- a/buildCmd/python/update/mod.go
+++ b/buildCmd/python/update/mod.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 )
 
-func Mod3(filePath string, newComment string) error {
+func EndMod(filePath string, newComment string) error {
     replaceTarget := regexp.MustCompile(`""" <location:[\s\S\n]*"""`)
     bytes, err := ioutil.ReadFile(filePath)
 	if err != nil {

--- a/clerk.yml
+++ b/clerk.yml
@@ -1,10 +1,8 @@
 lang: python
 spec:
-- location: greeting
+- location: proc
   modules:
-  - name: get
+  - name: run
     upstreams:
-      - name: ja
-        upstreams:
-          - name: listAll
-            comment: 日本語のあいさつ一覧を取得
+      - name: test
+        comment: テスト

--- a/cmd/buildCmd.go
+++ b/cmd/buildCmd.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/asweed888/clerk/buildCmd/commonjs"
 	"github.com/asweed888/clerk/buildCmd/python"
 	"github.com/asweed888/clerk/schema"
 	"github.com/urfave/cli/v2"
@@ -28,8 +27,8 @@ var BuildCommand = &cli.Command{
         switch scm.Lang {
             case "python":
                 err = python.Proc(scm)
-            case "commonjs":
-                err = commonjs.Proc(scm)
+            // case "commonjs":
+            //     err = commonjs.Proc(scm)
             default:
                 return fmt.Errorf("対応していない言語が指定されています。")
         }

--- a/schema/mod.go
+++ b/schema/mod.go
@@ -15,11 +15,8 @@ type ClerkYaml struct {
 		Modules  []struct {
 			Name      string `yaml:"name"`
 			Upstreams []struct {
-				Name      string `yaml:"name"`
-				Upstreams []struct {
-					Name    string `yaml:"name"`
-					Comment string `yaml:"comment"`
-				} `yaml:"upstreams"`
+				Name    string `yaml:"name"`
+				Comment string `yaml:"comment"`
 			} `yaml:"upstreams"`
 		} `yaml:"modules"`
 	} `yaml:"spec"`


### PR DESCRIPTION
## 詳細
- module rootはlocationのまま
- clerkディレクトリ内に出力する仕様を復活
- commonjsはpythonでの仕様が固まるまで無効化